### PR TITLE
Convert third party sources to ARC

### DIFF
--- a/src/xcov-core.xcodeproj/project.pbxproj
+++ b/src/xcov-core.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		072F06D51C5639E9004DAE1A /* DDCliApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06CD1C5639E9004DAE1A /* DDCliApplication.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		072F06D61C5639E9004DAE1A /* DDCliParseException.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06CF1C5639E9004DAE1A /* DDCliParseException.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		072F06D71C5639E9004DAE1A /* DDCliUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06D11C5639E9004DAE1A /* DDCliUtil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		072F06D81C5639E9004DAE1A /* DDGetoptLongParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06D41C5639E9004DAE1A /* DDGetoptLongParser.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		072F06D51C5639E9004DAE1A /* DDCliApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06CD1C5639E9004DAE1A /* DDCliApplication.m */; };
+		072F06D61C5639E9004DAE1A /* DDCliParseException.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06CF1C5639E9004DAE1A /* DDCliParseException.m */; };
+		072F06D71C5639E9004DAE1A /* DDCliUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06D11C5639E9004DAE1A /* DDCliUtil.m */; };
+		072F06D81C5639E9004DAE1A /* DDGetoptLongParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06D41C5639E9004DAE1A /* DDGetoptLongParser.m */; };
 		072F06DB1C563A28004DAE1A /* Middleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 072F06DA1C563A28004DAE1A /* Middleware.m */; };
 		C1E617EB1C5631D900FB32CE /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E617EA1C5631D900FB32CE /* main.m */; };
 		C1E618001C5631F700FB32CE /* IDESchemeActionCodeCoverage.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E617F31C5631F700FB32CE /* IDESchemeActionCodeCoverage.m */; };
@@ -346,6 +346,7 @@
 		C1E617EF1C5631D900FB32CE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -353,6 +354,7 @@
 		C1E617F01C5631D900FB32CE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/src/xcov-core/Third Parties/ddcli/DDCliApplication.m
+++ b/src/xcov-core/Third Parties/ddcli/DDCliApplication.m
@@ -46,7 +46,7 @@ DDCliApplication * DDCliApp = nil;
         return nil;
     
     NSProcessInfo * processInfo = [NSProcessInfo processInfo];
-    mName = [[processInfo processName] retain];
+    mName = [processInfo processName];
     
     return self;
 }
@@ -90,7 +90,6 @@ DDCliApplication * DDCliApp = nil;
     {
         if (delegate != nil)
         {
-            [delegate release];
             delegate = nil;
         }
     }
@@ -107,10 +106,9 @@ DDCliApplication * DDCliApp = nil;
 
 int DDCliAppRunWithClass(Class delegateClass)
 {
-    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    // Initialize singleton/global
-    DDCliApplication * app = [DDCliApplication sharedApplication];
-    int result = [app runWithClass: delegateClass];
-    [pool release];
-    return result;
+    @autoreleasepool {
+        // Initialize singleton/global
+        DDCliApplication * app = [DDCliApplication sharedApplication];
+        return [app runWithClass: delegateClass];
+    }
 }

--- a/src/xcov-core/Third Parties/ddcli/DDCliParseException.m
+++ b/src/xcov-core/Third Parties/ddcli/DDCliParseException.m
@@ -30,8 +30,8 @@
 + (DDCliParseException *) parseExceptionWithReason: (NSString *) reason
                                           exitCode: (int) exitCode;
 {
-    return [[[self alloc] initWithReason: reason
-                                exitCode: exitCode] autorelease];
+    return [[self alloc] initWithReason: reason
+                               exitCode: exitCode];
 }
 
 - (id) initWithReason: (NSString *) reason

--- a/src/xcov-core/Third Parties/ddcli/DDCliUtil.m
+++ b/src/xcov-core/Third Parties/ddcli/DDCliUtil.m
@@ -34,7 +34,6 @@ void ddfprintf(FILE * stream, NSString * format, ...)
     va_end(arguments);
     
     fprintf(stream, "%s", [string UTF8String]);
-    [string release];
 }
 
 void ddprintf(NSString * format, ...)
@@ -46,5 +45,4 @@ void ddprintf(NSString * format, ...)
     va_end(arguments);
     
     printf("%s", [string UTF8String]);
-    [string release];
 }

--- a/src/xcov-core/Third Parties/ddcli/DDGetoptLongParser.m
+++ b/src/xcov-core/Third Parties/ddcli/DDGetoptLongParser.m
@@ -44,7 +44,7 @@
 
 + (DDGetoptLongParser *) optionsWithTarget: (id) target;
 {
-    return [[[self alloc] initWithTarget: target] autorelease];
+    return [[self alloc] initWithTarget: target];
 }
 
 - (id) initWithTarget: (id) target;
@@ -65,15 +65,6 @@
     mGetoptFunction = getopt_long;
     
     return self;
-}
-
-- (void) dealloc
-{
-    [mOptionInfoMap release];
-    [mOptionString release];
-    [mOptionsData release];
-    
-    [super dealloc];
 }
 
 - (id) target;


### PR DESCRIPTION
This is done in order to have all the sources ARC compatible and to ensure memory management consistency over the entire project.
