### PR TITLE
Add file path ('location') to JSON report

### DIFF
--- a/src/xcov-core/Categories/NSDictionary+Report.m
+++ b/src/xcov-core/Categories/NSDictionary+Report.m
@@ -48,6 +48,7 @@
     }
     
     return @{@"name":file.name,
+             @"location":file.documentLocation,
              @"coverage":file.lineCoverage,
              @"functions":functions};
 }


### PR DESCRIPTION
Having full file paths allows us to implement different folder based exclusions in `xcov`. For example, to exclude all the files in a folder.
