### PR TITLE
Clean up  the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ $ xcov-core -s build/EasyPeasy.xccoverage -o report.json
 ### Parameters allowed
 * `--source` `-s`: Path to the `.xccoverage` file.
 * `--output` `-o`: Path to the resulting `.json` file.
-* `--add-location`: Add location field to file dictionary.
 * `--version` `-v`: Display version.
 * `--help` `-h`: Display this help.
 

--- a/src/xcov-core/Categories/NSDictionary+Report.h
+++ b/src/xcov-core/Categories/NSDictionary+Report.h
@@ -9,6 +9,6 @@
 
 @interface NSDictionary (Report)
 
-+ (NSDictionary*)dictionaryFromCodeCoverage:(IDESchemeActionCodeCoverage *)codeCoverage addingLocation:(BOOL)addLocation;
++ (NSDictionary*)dictionaryFromCodeCoverage:(IDESchemeActionCodeCoverage *)codeCoverage;
 
 @end

--- a/src/xcov-core/Categories/NSDictionary+Report.m
+++ b/src/xcov-core/Categories/NSDictionary+Report.m
@@ -12,11 +12,11 @@
 
 @implementation NSDictionary (Report)
 
-+ (NSDictionary*)dictionaryFromCodeCoverage:(IDESchemeActionCodeCoverage *)codeCoverage addingLocation:(BOOL)addLocation {
++ (NSDictionary*)dictionaryFromCodeCoverage:(IDESchemeActionCodeCoverage *)codeCoverage {
     NSMutableArray *targets = [NSMutableArray array];
     
     for (IDESchemeActionCodeCoverageTarget *target in codeCoverage.codeCoverageTargets) {
-        [targets addObject:[NSDictionary _dictionaryFromCodeCoverageTarget:target addingLocation:addLocation]];
+        [targets addObject:[NSDictionary _dictionaryFromCodeCoverageTarget:target]];
     }
     
     NSDictionary *dictionary = @{@"targets":targets};
@@ -26,11 +26,11 @@
 
 #pragma mark - Private class methods
 
-+ (NSDictionary*)_dictionaryFromCodeCoverageTarget:(IDESchemeActionCodeCoverageTarget *)target addingLocation:(BOOL)addLocation {
++ (NSDictionary*)_dictionaryFromCodeCoverageTarget:(IDESchemeActionCodeCoverageTarget *)target {
     NSMutableArray *files = [NSMutableArray array];
     
     for (IDESchemeActionCodeCoverageFile *file in target.sourceFiles) {
-        [files addObject:[NSDictionary _dictionaryFromCodeCoverageFile:file addingLocation:addLocation]];
+        [files addObject:[NSDictionary _dictionaryFromCodeCoverageFile:file]];
     }
     
     return @{@"name":target.name,
@@ -38,16 +38,14 @@
              @"files":files};
 }
 
-+ (NSDictionary*)_dictionaryFromCodeCoverageFile:(IDESchemeActionCodeCoverageFile *)file addingLocation:(BOOL)addLocation {
++ (NSDictionary*)_dictionaryFromCodeCoverageFile:(IDESchemeActionCodeCoverageFile *)file {
     NSMutableDictionary *dictionary = [[NSMutableDictionary alloc] init];
     dictionary[@"name"] = file.name;
     dictionary[@"coverage"] = file.lineCoverage;
     dictionary[@"functions"] = [file convertFunctionsToDictionaries];
     dictionary[@"lines"] = [file linesInfo];
     
-    if (addLocation) {
-        dictionary[@"location"] = file.documentLocation;
-    }
+    dictionary[@"location"] = file.documentLocation;
     
     return dictionary;
 }

--- a/src/xcov-core/Core/CoreOptions.h
+++ b/src/xcov-core/Core/CoreOptions.h
@@ -8,5 +8,4 @@
 typedef struct {
     __unsafe_unretained NSString *source;
     __unsafe_unretained NSString *target;
-    BOOL addLocation;
 } CoreOptions;

--- a/src/xcov-core/Core/Reader.m
+++ b/src/xcov-core/Core/Reader.m
@@ -44,9 +44,8 @@
         exit(65);
     }
     
-    ddprintf(@"Add file location? %@\n", self.options.addLocation ? @"yes" : @"no");
     ddprintf(@"Parsing .xccoverage file...\n");
-    NSDictionary *report = [NSDictionary dictionaryFromCodeCoverage:coverage addingLocation:self.options.addLocation];
+    NSDictionary *report = [NSDictionary dictionaryFromCodeCoverage:coverage];
     if (report == nil) {
         ddprintf(@"Unable to parse .xccoverage file\n");
         exit(65);
@@ -60,10 +59,7 @@
 - (BOOL)_isValidPath {
     BOOL isDirectory;
     if ([self.fileManager fileExistsAtPath:self.options.source isDirectory:&isDirectory]) {
-        if (isDirectory) {
-            return NO;
-        }
-        return YES;
+        return !isDirectory;
     }
     return NO;
 }

--- a/src/xcov-core/IDE/DVTSourceFileCodeCoverageRange.h
+++ b/src/xcov-core/IDE/DVTSourceFileCodeCoverageRange.h
@@ -7,7 +7,6 @@
 
 @interface DVTSourceFileCodeCoverageRange : NSObject <NSCoding>
 
-@property(readonly, nonatomic) BOOL executable;
 @property(readonly, nonatomic) unsigned long long length;
 @property(readonly, nonatomic) unsigned long long column;
 @property(readonly, nonatomic) unsigned long long line;

--- a/src/xcov-core/IDE/DVTSourceFileCodeCoverageRange.m
+++ b/src/xcov-core/IDE/DVTSourceFileCodeCoverageRange.m
@@ -11,8 +11,7 @@
     self = [super init];
     
     if (self != nil) {
-        _executionCount = [aDecoder decodeIntForKey:@"c"];
-        _executable = [aDecoder decodeIntForKey:@"x"];
+        _executionCount = [aDecoder decodeIntForKey:@"x"];
         _length = [aDecoder decodeInt64ForKey:@"len"];
         _column = [aDecoder decodeInt64ForKey:@"c"];
         _line = [aDecoder decodeInt64ForKey:@"l"];

--- a/src/xcov-core/Middleware.h
+++ b/src/xcov-core/Middleware.h
@@ -9,7 +9,6 @@
 @interface Middleware : NSObject <DDCliApplicationDelegate> {
     NSString * _source;
     NSString * _output;
-    BOOL _addLocation;
     BOOL _version;
     BOOL _help;
 }

--- a/src/xcov-core/Middleware.m
+++ b/src/xcov-core/Middleware.m
@@ -41,7 +41,6 @@ NSString *const MiddlewareAppName       = @"xcov-core";
     DDGetoptOption optionTable[] = {
         {@"source",       's',    DDGetoptRequiredArgument},
         {@"output",       'o',    DDGetoptRequiredArgument},
-        {@"add-location",   0,    DDGetoptNoArgument},
         {@"help",         'h',    DDGetoptNoArgument},
         {@"version",      'v',    DDGetoptNoArgument},
         {nil,               0,    0},
@@ -56,7 +55,6 @@ NSString *const MiddlewareAppName       = @"xcov-core";
     CoreOptions options;
     options.source = [self convertToAbsolutePath:_source];
     options.target = [self convertToAbsolutePath:_output];
-    options.addLocation = _addLocation;
     
     Core *core = [[Core alloc] initWithOptions:options];
     [core run];
@@ -71,7 +69,6 @@ NSString *const MiddlewareAppName       = @"xcov-core";
     ddprintf(@"\n"
              @"  -s, --source FILE             Full path to the .xccoverage file\n"
              @"  -o, --output FILE             Full path to the resulting .json file\n"
-             @"      --add-location            Add location field to file dictionary\n"
              @"  -v  --version                 Display version\n"
              @"  -h, --help                    Display this help\n"
              @"\n"

--- a/src/xcov-core/Middleware.m
+++ b/src/xcov-core/Middleware.m
@@ -14,7 +14,7 @@ NSString *const MiddlewareAppName       = @"xcov-core";
 
 #pragma mark - DDCliApplicationDelegate methods
 
-- (int)application:(DDCliApplication *)app runWithArguments: (NSArray *)arguments {
+- (int)application:(DDCliApplication *)app runWithArguments:(NSArray *)arguments {
     
     ddprintf(@"------ %@ ------\n", MiddlewareAppName);
     
@@ -47,7 +47,7 @@ NSString *const MiddlewareAppName       = @"xcov-core";
         {nil,               0,    0},
     };
     
-    [optionsParser addOptionsFromTable: optionTable];
+    [optionsParser addOptionsFromTable:optionTable];
 }
 
 #pragma mark - Private methods


### PR DESCRIPTION
* Removed wrongly computed 'executable' property
* Fixed some coding style inconsistencies
* Removed '--add-location' option
> As we always use full file paths in `xcov`, there is no practical
> reason to keep this option.
> Removing it leads to a slightly cleaner code and fewer booleans.