### PR TITLE
Add support for relative paths for input and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ $ xcov-core -s build/EasyPeasy.xccoverage -o report.json
 ```
 
 ### Parameters allowed
-* `--source` `-s`: Full path to the `.xccoverage` file.
-* `--output` `-o`: Full path to the resulting `.json` file.
+* `--source` `-s`: Path to the `.xccoverage` file.
+* `--output` `-o`: Path to the resulting `.json` file.
 * `--add-location`: Add location field to file dictionary.
 * `--version` `-v`: Display version.
 * `--help` `-h`: Display this help.

--- a/src/xcov-core/Middleware.m
+++ b/src/xcov-core/Middleware.m
@@ -54,8 +54,8 @@ NSString *const MiddlewareAppName       = @"xcov-core";
 
 - (void)_runCore {
     CoreOptions options;
-    options.source = _source;
-    options.target = _output;
+    options.source = [self convertToAbsolutePath:_source];
+    options.target = [self convertToAbsolutePath:_output];
     options.addLocation = _addLocation;
     
     Core *core = [[Core alloc] initWithOptions:options];
@@ -80,6 +80,18 @@ NSString *const MiddlewareAppName       = @"xcov-core";
 
 - (void)_printVersion {
     ddprintf(@"%@ v.%@ - Created by Carlos Vidal (@carlostify)\n", MiddlewareAppName, MiddlewareAppVersion);
+}
+
+- (NSString *)convertToAbsolutePath:(NSString *)path {
+    if([path hasPrefix:@"/"]) { // it's already an absolute path
+        return path;
+    }
+
+    if([path hasPrefix:@"~"]) { // is relative to user folder
+        return [path stringByExpandingTildeInPath];
+    }
+
+    return [[[NSURL alloc] initFileURLWithPath:path] path];
 }
 
 @end


### PR DESCRIPTION
This allows you to call `xcov-core` like this:
```
$ xcov-core -s EasyPeasy.xccoverage -o ~/Desktop/report.json
```