### PR TITLE
Fix crash when absolute paths are created from relative or user paths

### DIFF
--- a/src/xcov-core/Middleware.m
+++ b/src/xcov-core/Middleware.m
@@ -51,10 +51,16 @@ NSString *const MiddlewareAppName       = @"xcov-core";
 #pragma mark - Private methods
 
 - (void)_runCore {
+    
+    NSString *source = [self convertToAbsolutePath:_source];
+    NSString *target = [self convertToAbsolutePath:_output];
+    NSString *ideFoundationPath = [self convertToAbsolutePath:_ideFoundationPath];
+
     CoreOptions options;
-    options.source = [self convertToAbsolutePath:_source];
-    options.target = [self convertToAbsolutePath:_output];
-    options.ideFoundationPath = [self convertToAbsolutePath:_ideFoundationPath];
+    options.source = source;
+    options.target = target;
+    options.ideFoundationPath = ideFoundationPath;
+
     Core *core = [[Core alloc] initWithOptions:options];
     [core run];
 }


### PR DESCRIPTION

Ran into a bug where the absolute paths are created but were getting deallocated before they could be used. I'm not Obj-C coder so this may not be the best solution but I just store the values locally so there is a reference to them while it runs. 

**Command**
`xcov-core  -s action_0.xccovreport -o report.json -x /Applications/Xcode.app/Contents/Frameworks/IDEFoundation.framework/IDEFoundation`

**Output**
```Opening .xccoverage file at path: /Users/bpollman/release/repo/app/action_0.xccovreport
Parsing .xccoverage file...
File successfully parsed
fish: '/Users/bpollman/Library/Develop…' terminated by signal SIGSEGV (Address boundary error)```