### PR TITLE
Move to using an object with strong properties for CoreOptions.

### DIFF
--- a/src/xcov-core.xcodeproj/project.pbxproj
+++ b/src/xcov-core.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		C1E618121C56326900FB32CE /* Core.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E6180D1C56326900FB32CE /* Core.m */; };
 		C1E618131C56326900FB32CE /* Reader.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E6180F1C56326900FB32CE /* Reader.m */; };
 		C1E618141C56326900FB32CE /* Writer.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E618111C56326900FB32CE /* Writer.m */; };
+		F33D18D223691B950038B564 /* CoreOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = F33D18D123691B950038B564 /* CoreOptions.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -63,6 +64,7 @@
 		C1E6180F1C56326900FB32CE /* Reader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Reader.m; sourceTree = "<group>"; };
 		C1E618101C56326900FB32CE /* Writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Writer.h; sourceTree = "<group>"; };
 		C1E618111C56326900FB32CE /* Writer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Writer.m; sourceTree = "<group>"; };
+		F33D18D123691B950038B564 /* CoreOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CoreOptions.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +151,7 @@
 			isa = PBXGroup;
 			children = (
 				C1234B151D303B96004AB3A1 /* CoreOptions.h */,
+				F33D18D123691B950038B564 /* CoreOptions.m */,
 				C1E6180C1C56326900FB32CE /* Core.h */,
 				C1E6180D1C56326900FB32CE /* Core.m */,
 				C1E6180E1C56326900FB32CE /* Reader.h */,
@@ -224,6 +227,7 @@
 				072F06D81C5639E9004DAE1A /* DDGetoptLongParser.m in Sources */,
 				072F06D71C5639E9004DAE1A /* DDCliUtil.m in Sources */,
 				C1E617EB1C5631D900FB32CE /* main.m in Sources */,
+				F33D18D223691B950038B564 /* CoreOptions.m in Sources */,
 				A381D1B91E166A34002A644A /* DVTSourceFileLineCoverageData+Report.m in Sources */,
 				072F06D61C5639E9004DAE1A /* DDCliParseException.m in Sources */,
 				A341BF2A1DD7BABA002F5084 /* IDESchemeActionCodeCoverageFile+Report.m in Sources */,

--- a/src/xcov-core/Core/Core.h
+++ b/src/xcov-core/Core/Core.h
@@ -8,7 +8,7 @@
 
 @interface Core : NSObject
 
-- (instancetype)initWithOptions:(CoreOptions)options;
+- (instancetype)initWithOptions:(CoreOptions *)options;
 - (void)run;
 
 @end

--- a/src/xcov-core/Core/Core.m
+++ b/src/xcov-core/Core/Core.m
@@ -9,7 +9,7 @@
 
 @interface Core()
 
-@property (nonatomic, assign, readonly) CoreOptions options;
+@property (nonatomic, assign, readonly) CoreOptions *options;
 
 @property (nonatomic, strong, readonly) Reader *reader;
 @property (nonatomic, strong, readonly) Writer *writer;
@@ -21,7 +21,7 @@
 @synthesize reader = _reader;
 @synthesize writer = _writer;
 
-- (instancetype)initWithOptions:(CoreOptions)options {
+- (instancetype)initWithOptions:(CoreOptions *)options {
     self = [super init];
 
     if (self != nil) {

--- a/src/xcov-core/Core/CoreOptions.h
+++ b/src/xcov-core/Core/CoreOptions.h
@@ -5,8 +5,10 @@
 
 #import<Foundation/Foundation.h>
 
-typedef struct {
-    __unsafe_unretained NSString *source;
-    __unsafe_unretained NSString *target;
-    __unsafe_unretained NSString *ideFoundationPath;
-} CoreOptions;
+@interface CoreOptions : NSObject
+
+@property(nonatomic, strong) NSString *source;
+@property(nonatomic, strong) NSString *target;
+@property(nonatomic, strong) NSString *ideFoundationPath;
+
+@end

--- a/src/xcov-core/Core/CoreOptions.m
+++ b/src/xcov-core/Core/CoreOptions.m
@@ -1,0 +1,10 @@
+//
+//  Created by Spencer Whyte on 2019-10-29.
+//  Copyright © 2019 nakioStudio. All rights reserved.
+//
+
+#import "CoreOptions.h"
+
+@implementation CoreOptions
+
+@end

--- a/src/xcov-core/Core/Reader.h
+++ b/src/xcov-core/Core/Reader.h
@@ -8,7 +8,7 @@
 
 @interface Reader : NSObject
 
-- (instancetype)initWithOptions:(CoreOptions)options;
+- (instancetype)initWithOptions:(CoreOptions *)options;
 - (NSDictionary *)read;
 
 @end

--- a/src/xcov-core/Core/Reader.m
+++ b/src/xcov-core/Core/Reader.m
@@ -10,14 +10,14 @@
 
 @interface Reader()
 
-@property (nonatomic, assign, readonly) CoreOptions options;
+@property (nonatomic, strong, readonly) CoreOptions *options;
 @property (nonatomic, strong, readonly) NSFileManager *fileManager;
 
 @end
 
 @implementation Reader
 
-- (instancetype)initWithOptions:(CoreOptions)options {
+- (instancetype)initWithOptions:(CoreOptions *)options {
     self = [super init];
     
     if (self != nil) {

--- a/src/xcov-core/Core/Writer.h
+++ b/src/xcov-core/Core/Writer.h
@@ -8,7 +8,7 @@
 
 @interface Writer : NSObject
 
-- (instancetype)initWithOptions:(CoreOptions)options;
+- (instancetype)initWithOptions:(CoreOptions *)options;
 - (void)writeReport:(NSDictionary*)report;
 
 @end

--- a/src/xcov-core/Core/Writer.m
+++ b/src/xcov-core/Core/Writer.m
@@ -9,14 +9,14 @@
 
 @interface Writer()
 
-@property (nonatomic, assign, readonly) CoreOptions options;
+@property (nonatomic, strong, readonly) CoreOptions *options;
 @property (nonatomic, strong, readonly) NSFileManager *fileManager;
 
 @end
 
 @implementation Writer
 
-- (instancetype)initWithOptions:(CoreOptions)options {
+- (instancetype)initWithOptions:(CoreOptions *)options {
     self = [super init];
     
     if (self != nil) {

--- a/src/xcov-core/Middleware.m
+++ b/src/xcov-core/Middleware.m
@@ -51,7 +51,7 @@ NSString *const MiddlewareAppName       = @"xcov-core";
 #pragma mark - Private methods
 
 - (void)_runCore {
-    CoreOptions options;
+    CoreOptions *options = [[CoreOptions alloc] init];
     options.source = [self convertToAbsolutePath:_source];
     options.target = [self convertToAbsolutePath:_output];
     options.ideFoundationPath = [self convertToAbsolutePath:_ideFoundationPath];


### PR DESCRIPTION
This way properties are not prematurely deallocated. 

This PR solves the same problem as https://github.com/fastlane-community/xcov-core/pull/15, it just tries to do it in a less-hacky way.

@joshdholtz This fixes https://github.com/fastlane-community/xcov/issues/159 so you'd need to cut a new release to get things working for everyone on Catalina.